### PR TITLE
Set e to get exception when not 401 status code

### DIFF
--- a/custom_components/eloverblik/__init__.py
+++ b/custom_components/eloverblik/__init__.py
@@ -110,11 +110,12 @@ class HassEloverblik:
             if he.response.status_code == 401:
                 message = f"Unauthorized error while accessing eloverblik.dk. Wrong or expired refresh token?"
             else:
+                e = sys.exc_info()[1]
                 message = f"Exception: {e}"
 
             _LOGGER.warn(message)
         except: 
-            e = sys.exc_info()[0]
+            e = sys.exc_info()[1]
             _LOGGER.warn(f"Exception: {e}")
 
         _LOGGER.debug("Done fetching data from Eloverblik")


### PR DESCRIPTION
I got a lot of exceptions starting with "e was referenced before assignment".
It seemed that the exception made it keep retrying getting the token.
The actual exception was 503 Server Error: Service Unavailable for url: https://api.eloverblik.dk/CustomerApi/api/Token.