### PR TITLE
#51: Added sensor for sum of tariffs.

### DIFF
--- a/README.md
+++ b/README.md
@@ -123,3 +123,39 @@ template:
         state_class: measurement
         last_reset: "{{ state_attr('sensor.eloverblik_energy_total', 'metering_date') }}"
 ```
+
+### Forecast total kWh price with Nordpool integration
+
+If you have the [Nordpool](https://github.com/custom-components/nordpool) installed you can calculate the current electricity price and forecast the price for today and tomorrow by the hour. These prices will including any tarrifs that apply, which will adjust according to peak times and season as they are fetched from Eloverblik. This way you will get the actual price you pay per kWh. You can plot this on a dashboard, or use it in the Energy dashboard.
+
+To combine the the nordpool and eloverblik sensors, create the following template sensor:
+
+```
+template:
+  - sensor:
+    - name: "Electricity Cost"
+      unique_id: electricity_cost
+      device_class: monetary
+      unit_of_measurement: "kr/kWh"
+      state: >
+        {{ float(states('sensor.eloverblik_tariff_sum')) + float(states('sensor.nordpool')) }}
+      attributes:
+        today: >
+          {% if state_attr('sensor.eloverblik_tariff_sum', 'hourly') and state_attr('sensor.nordpool', 'today') %}
+            {% set ns = namespace (prices=[]) %}
+            {% for h in range(24) %}
+              {% set ns.prices = ns.prices + [(float(state_attr('sensor.eloverblik_tariff_sum', 'hourly')[h]) + float(state_attr('sensor.nordpool', 'today')[h])) | round(5)] %}
+            {% endfor %}
+            {{ ns.prices }}
+          {% endif %}
+        tomorrow: >
+          {% if state_attr('sensor.eloverblik_tariff_sum', 'hourly') and state_attr('sensor.nordpool', 'tomorrow') %}
+            {% set ns = namespace (prices=[]) %}
+            {% for h in range(24) %}
+              {% set ns.prices = ns.prices + [(float(state_attr('sensor.eloverblik_tariff_sum', 'hourly')[h]) + float(state_attr('sensor.nordpool', 'tomorrow')[h])) | round(5)] %}
+            {% endfor %}
+            {{ ns.prices }}
+          {% endif %}
+```
+
+Replace `nordpool` with the name of your Nordpool sensor.

--- a/README.md
+++ b/README.md
@@ -144,7 +144,7 @@ template:
           {% if state_attr('sensor.eloverblik_tariff_sum', 'hourly') and state_attr('sensor.nordpool', 'today') %}
             {% set ns = namespace (prices=[]) %}
             {% for h in range(24) %}
-              {% set ns.prices = ns.prices + [(float(state_attr('sensor.eloverblik_tariff_sum', 'hourly')[h]) + float(state_attr('sensor.nordpool', 'today')[h])) | round(5)] %}
+              {% set ns.prices = ns.prices + [(1.25 * float(state_attr('sensor.eloverblik_tariff_sum', 'hourly')[h]) + float(state_attr('sensor.nordpool', 'today')[h])) | round(5)] %}
             {% endfor %}
             {{ ns.prices }}
           {% endif %}
@@ -152,7 +152,7 @@ template:
           {% if state_attr('sensor.eloverblik_tariff_sum', 'hourly') and state_attr('sensor.nordpool', 'tomorrow') %}
             {% set ns = namespace (prices=[]) %}
             {% for h in range(24) %}
-              {% set ns.prices = ns.prices + [(float(state_attr('sensor.eloverblik_tariff_sum', 'hourly')[h]) + float(state_attr('sensor.nordpool', 'tomorrow')[h])) | round(5)] %}
+              {% set ns.prices = ns.prices + [(1.25 * float(state_attr('sensor.eloverblik_tariff_sum', 'hourly')[h]) + float(state_attr('sensor.nordpool', 'tomorrow')[h])) | round(5)] %}
             {% endfor %}
             {{ ns.prices }}
           {% endif %}

--- a/custom_components/eloverblik/const.py
+++ b/custom_components/eloverblik/const.py
@@ -1,3 +1,4 @@
 """Constants for the Eloverblik integration."""
 
 DOMAIN = "eloverblik"
+CURRENCY_KRONER_PER_KILO_WATT_HOUR = "kr/kWh"

--- a/custom_components/eloverblik/manifest.json
+++ b/custom_components/eloverblik/manifest.json
@@ -5,7 +5,7 @@
   "config_flow": true,
   "documentation": "https://www.home-assistant.io/integrations/eloverblik",
   "requirements": [
-    "pyeloverblik==0.3.0"
+    "pyeloverblik==0.3.1"
   ],
   "ssdp": [],
   "zeroconf": [],

--- a/custom_components/eloverblik/sensor.py
+++ b/custom_components/eloverblik/sensor.py
@@ -121,7 +121,9 @@ class EloverblikTariff(Entity):
     @property
     def extra_state_attributes(self):
         """Return state attributes."""
-        attributes = {f"hour_{i}": self._data_hourly_tariff_sums[i] for i in range(24)}
+        attributes = {
+            "hourly": [self._data_hourly_tariff_sums[i] for i in range(24)]
+        }
         
         return attributes
 


### PR DESCRIPTION
This PR adds a new sensor for the sum of all tariffs for the current hour. The sensor also has an attribute for each hour of the day with the sum of tariffs for that hour.

The values will not be correct until https://github.com/JonasPed/pyeloverblik/pull/14 is merged and the dependency updated.

Once this is merged, it'll be possible to plot a forecast of actual prices when combined with the Nordpool integration, so when I get there, I'll add an example of that to the documentation.