### PR TITLE
 Updated readme example: "Forecast total kWh price", to include tax on the whole price and not just the tariffs

### DIFF
--- a/README.md
+++ b/README.md
@@ -139,21 +139,21 @@ template:
       device_class: monetary
       unit_of_measurement: "kr/kWh"
       state: >
-        {{ (1.25 * float(states('sensor.eloverblik_tariff_sum'))) + float(states('sensor.nordpool')) }}
+        {{ 1.25 * (float(states('sensor.eloverblik_tariff_sum')) + float(states('sensor.nordpool_kwh_dk2_dkk_2_095_025'))) }}
       attributes:
         today: >
-          {% if state_attr('sensor.eloverblik_tariff_sum', 'hourly') and state_attr('sensor.nordpool', 'today') %}
+          {% if state_attr('sensor.eloverblik_tariff_sum', 'hourly') and state_attr('sensor.nordpool_kwh_dk2_dkk_2_095_025', 'today') %}
             {% set ns = namespace (prices=[]) %}
             {% for h in range(24) %}
-              {% set ns.prices = ns.prices + [(1.25 * float(state_attr('sensor.eloverblik_tariff_sum', 'hourly')[h]) + float(state_attr('sensor.nordpool', 'today')[h])) | round(5)] %}
+              {% set ns.prices = ns.prices + [(1.25 * (float(state_attr('sensor.eloverblik_tariff_sum', 'hourly')[h]) + float(state_attr('sensor.nordpool_kwh_dk2_dkk_2_095_025', 'today')[h]))) | round(5)] %}
             {% endfor %}
             {{ ns.prices }}
           {% endif %}
         tomorrow: >
-          {% if state_attr('sensor.eloverblik_tariff_sum', 'hourly') and state_attr('sensor.nordpool', 'tomorrow') %}
+          {% if state_attr('sensor.eloverblik_tariff_sum', 'hourly') and state_attr('sensor.nordpool_kwh_dk2_dkk_2_095_025', 'tomorrow') %}
             {% set ns = namespace (prices=[]) %}
             {% for h in range(24) %}
-              {% set ns.prices = ns.prices + [(1.25 * float(state_attr('sensor.eloverblik_tariff_sum', 'hourly')[h]) + float(state_attr('sensor.nordpool', 'tomorrow')[h])) | round(5)] %}
+              {% set ns.prices = ns.prices + [(1.25 * (float(state_attr('sensor.eloverblik_tariff_sum', 'hourly')[h]) + float(state_attr('sensor.nordpool_kwh_dk2_dkk_2_095_025', 'tomorrow')[h]))) | round(5)] %}
             {% endfor %}
             {{ ns.prices }}
           {% endif %}

--- a/README.md
+++ b/README.md
@@ -139,21 +139,21 @@ template:
       device_class: monetary
       unit_of_measurement: "kr/kWh"
       state: >
-        {{ 1.25 * (float(states('sensor.eloverblik_tariff_sum')) + float(states('sensor.nordpool_kwh_dk2_dkk_2_095_025'))) }}
+        {{ 1.25 * (float(states('sensor.eloverblik_tariff_sum')) + float(states('sensor.nordpool'))) }}
       attributes:
         today: >
-          {% if state_attr('sensor.eloverblik_tariff_sum', 'hourly') and state_attr('sensor.nordpool_kwh_dk2_dkk_2_095_025', 'today') %}
+          {% if state_attr('sensor.eloverblik_tariff_sum', 'hourly') and state_attr('sensor.nordpool', 'today') %}
             {% set ns = namespace (prices=[]) %}
             {% for h in range(24) %}
-              {% set ns.prices = ns.prices + [(1.25 * (float(state_attr('sensor.eloverblik_tariff_sum', 'hourly')[h]) + float(state_attr('sensor.nordpool_kwh_dk2_dkk_2_095_025', 'today')[h]))) | round(5)] %}
+              {% set ns.prices = ns.prices + [(1.25 * (float(state_attr('sensor.eloverblik_tariff_sum', 'hourly')[h]) + float(state_attr('sensor.nordpool', 'today')[h]))) | round(5)] %}
             {% endfor %}
             {{ ns.prices }}
           {% endif %}
         tomorrow: >
-          {% if state_attr('sensor.eloverblik_tariff_sum', 'hourly') and state_attr('sensor.nordpool_kwh_dk2_dkk_2_095_025', 'tomorrow') %}
+          {% if state_attr('sensor.eloverblik_tariff_sum', 'hourly') and state_attr('sensor.nordpool', 'tomorrow') %}
             {% set ns = namespace (prices=[]) %}
             {% for h in range(24) %}
-              {% set ns.prices = ns.prices + [(1.25 * (float(state_attr('sensor.eloverblik_tariff_sum', 'hourly')[h]) + float(state_attr('sensor.nordpool_kwh_dk2_dkk_2_095_025', 'tomorrow')[h]))) | round(5)] %}
+              {% set ns.prices = ns.prices + [(1.25 * (float(state_attr('sensor.eloverblik_tariff_sum', 'hourly')[h]) + float(state_attr('sensor.nordpool', 'tomorrow')[h]))) | round(5)] %}
             {% endfor %}
             {{ ns.prices }}
           {% endif %}


### PR DESCRIPTION
Minor correction, so government tax is added to the total price: 1.25 * (raw_electricity_cost+tariffs)