### PR TITLE
Clarify log statement and bump pyeloverblik.

### DIFF
--- a/custom_components/eloverblik/__init__.py
+++ b/custom_components/eloverblik/__init__.py
@@ -220,7 +220,7 @@ class HassEloverblik:
             if meter_reading_data.status == 200:
                 self._meter_reading_data = meter_reading_data
             else:
-                _LOGGER.warn(f"Error from eloverblik when getting meter rading data: {meter_reading_data.status} - {meter_reading_data.detailed_status}")
+                _LOGGER.info(f"Error from eloverblik when getting meter reading data: {meter_reading_data.status} - {meter_reading_data.detailed_status}. This is not a bug. Just an indication that data is not available in Eloverblik.dk.")
         except requests.exceptions.HTTPError as he:
             message = None
             if he.response.status_code == 401:

--- a/custom_components/eloverblik/manifest.json
+++ b/custom_components/eloverblik/manifest.json
@@ -5,7 +5,7 @@
   "config_flow": true,
   "documentation": "https://www.home-assistant.io/integrations/eloverblik",
   "requirements": [
-    "pyeloverblik==0.4.0"
+    "pyeloverblik==0.4.1"
   ],
   "ssdp": [],
   "zeroconf": [],


### PR DESCRIPTION
Add information to log statement that it is not an error. 
Further bump pyeloverblik to read further back in time to get latest meter reading, if such exists.