### PR TITLE
Fix #100: async_forward_entry_setup deprecated from Home Assistant 2025.1

### DIFF
--- a/custom_components/eloverblik/__init__.py
+++ b/custom_components/eloverblik/__init__.py
@@ -37,8 +37,8 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry):
     hass.data[DOMAIN][entry.entry_id] = HassEloverblik(refresh_token, metering_point)
 
     for component in PLATFORMS:
-        hass.async_create_task(
-            hass.config_entries.async_forward_entry_setup(entry, component)
+        await hass.async_create_task(
+            hass.config_entries.async_forward_entry_setups(entry, component)
         )
 
     return True


### PR DESCRIPTION
Fixes #100 