### PR TITLE
Specify mean_type and unit_class when importing statistics

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -3,7 +3,7 @@
 {
 	"name": "Python 3",
 	// Or use a Dockerfile or Docker Compose file. More info: https://containers.dev/guide/dockerfile
-	"image": "mcr.microsoft.com/devcontainers/python:0-3.10",
+	"image": "mcr.microsoft.com/devcontainers/python:3-3.14",
 
 	// Features to add to the dev container. More info: https://containers.dev/features.
 	// "features": {},

--- a/custom_components/eloverblik/manifest.json
+++ b/custom_components/eloverblik/manifest.json
@@ -1,7 +1,7 @@
 {
   "domain": "eloverblik",
   "name": "Eloverblik",
-  "version": "0.7.0",
+  "version": "0.6.2",
   "config_flow": true,
   "documentation": "https://github.com/JonasPed/homeassistant-eloverblik",
   "issue_tracker": "https://github.com/JonasPed/homeassistant-eloverblik/issues",

--- a/custom_components/eloverblik/manifest.json
+++ b/custom_components/eloverblik/manifest.json
@@ -1,7 +1,7 @@
 {
   "domain": "eloverblik",
   "name": "Eloverblik",
-  "version": "0.6.1",
+  "version": "0.7.0",
   "config_flow": true,
   "documentation": "https://github.com/JonasPed/homeassistant-eloverblik",
   "issue_tracker": "https://github.com/JonasPed/homeassistant-eloverblik/issues",

--- a/custom_components/eloverblik/sensor.py
+++ b/custom_components/eloverblik/sensor.py
@@ -11,6 +11,7 @@ from homeassistant.components.recorder.statistics import (
 )
 from homeassistant.components.recorder.models import (
     StatisticData,
+    StatisticMeanType,
     StatisticMetaData
 )
 from homeassistant.config_entries import ConfigEntry
@@ -21,6 +22,7 @@ from homeassistant.components.sensor import (
     SensorStateClass,
 )
 from homeassistant.util import Throttle
+from homeassistant.util.unit_conversion import EnergyConverter
 from homeassistant.helpers.entity import Entity
 from pyeloverblik.models import TimeSeries
 from .__init__ import HassEloverblik, MIN_TIME_BETWEEN_UPDATES
@@ -294,7 +296,8 @@ class EloverblikStatistic(SensorEntity):
             source=RECORDER_DOMAIN,
             statistic_id=self.entity_id,
             unit_of_measurement=UnitOfEnergy.KILO_WATT_HOUR,
-            has_mean=False,
+            unit_class=EnergyConverter.UNIT_CLASS,
+            mean_type=StatisticMeanType.NONE,
             has_sum=True,
         )
 

--- a/hacs.json
+++ b/hacs.json
@@ -1,4 +1,5 @@
 {
     "name": "Eloverblik",
-    "render_readme": true
+    "render_readme": true,
+    "homeassistant": "2025.4.0"
 }

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,1 @@
-homeassistant==2023.1.3
+homeassistant==2026.8.1


### PR DESCRIPTION
Fixes the deprecation warnings from `async_import_statistics`, which break in HA 2026.11:

```
Detected that custom integration 'eloverblik' doesn't specify mean_type when
calling async_import_statistics at custom_components/eloverblik/sensor.py, line 302
```

`async_import_statistics` warns for **two** missing keys, so both are now set:

- `mean_type=StatisticMeanType.NONE` replaces the deprecated `has_mean=False`
- `unit_class=EnergyConverter.UNIT_CLASS` (`energy`)

Also raises the minimum HA version to 2025.4.0 (`StatisticMeanType`), and bumps the devcontainer to Python 3.14, since HA 2026.3+ requires >= 3.14.2 and the pinned 3.10 image could not install a current HA.

Verified against HA 2026.8.1: the integration imports cleanly, the metadata passes the `statistic_id`/`source` guards, neither `report_usage` branch can fire, and `unit_class` matches the converter registered for kWh.

Fixes #118 